### PR TITLE
hybris: use x86-64 for amd64 instead of x86

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -78,7 +78,7 @@ ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), amd64))
 FLATPAK_ARCH = x86_64
 FLATPAK_LIBDIR = lib64
 ARCH_CONFIGURATION = \
-	--enable-arch=x86
+	--enable-arch=x86-64
 endif
 
 FLATPAK_EXTENSION_TARGET = var/lib/flatpak/extension/org.freedesktop.Platform.GL.hybris/$(FLATPAK_ARCH)/1.4


### PR DESCRIPTION
HYBRIS_LD_LIBRARY_PATH and other vars fail to set properly because it is looking for /system/lib instead of /system/lib64. 
This was the root cause of that issue. 