### PR TITLE
Fix executable stack error for libhybris-common1.so

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -13,6 +13,9 @@ m4_define([hybris_lt_current], [1])
 m4_define([hybris_lt_revision], [0])
 m4_define([hybris_lt_age], [0])
 
+# noexecstack
+LDFLAGS="$LDFLAGS -Wl,-z,noexecstack"
+
 AC_PROG_CC
 AC_PROG_CXX
 AM_PROG_CC_C_O


### PR DESCRIPTION
Fix "MESA-LOADER: failed to open hybris: libhybris-common.so.1: cannot enable executable stack as shared object requires: Invalid argument (search paths /usr/lib/aarch64-linux-gnu/gbm, suffix _gbm)"